### PR TITLE
Fix time zone string for OSX

### DIFF
--- a/ShipStation4Net/ClientBase.cs
+++ b/ShipStation4Net/ClientBase.cs
@@ -75,7 +75,7 @@ namespace ShipStation4Net
 			var timezoneString = "Pacific Standard Time";
 
 #if NETSTANDARD2_0
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 timezoneString = "America/Los_Angeles";
             }


### PR DESCRIPTION
System.TypeInitializationException: The type initializer for 'ShipStation4Net.ClientBase' threw an exception.
 ---> System.TimeZoneNotFoundException: The time zone ID 'Pacific Standard Time' was not found on the local computer.

otherwise.