### PR TITLE
* Added this missing property. On an existing order if you try and up…

### DIFF
--- a/ShipStation4Net/Domain/Entities/AdvancedOptions.cs
+++ b/ShipStation4Net/Domain/Entities/AdvancedOptions.cs
@@ -118,5 +118,11 @@ namespace ShipStation4Net.Domain.Entities
         /// </summary>
         [JsonProperty("billToCountryCode")]
         public string BillToCountryCode { get; set; }
+        
+        /// <summary>
+        /// Country Code of billToMyOtherAccount.
+        /// </summary>
+        [JsonProperty("billToMyOtherAccount")]
+        public string BillToMyOtherAccount { get; set; }
     }
 }


### PR DESCRIPTION
Added this missing property. On an existing order if you try and update the Shipstation order containing this property and you don't supply it in your update request. You'll get a 400 Bad Request due to the missing property in the update request not being supplied.

Hopefully this saves someone else the time chasing this one down