### PR TITLE
Added ProductType entity and changed property on Product entity

### DIFF
--- a/ShipStation4Net/Domain/Entities/Product.cs
+++ b/ShipStation4Net/Domain/Entities/Product.cs
@@ -113,7 +113,7 @@ namespace ShipStation4Net.Domain.Entities
         /// Specifies the product type. See our knowledge base here for more information on Product Types.
         /// </summary>
         [JsonProperty("productType")]
-        public string ProductType { get; set; }
+        public ProductType ProductType { get; set; }
 
         /// <summary>
         /// The warehouse location associated with the product record.

--- a/ShipStation4Net/Domain/Entities/ProductType.cs
+++ b/ShipStation4Net/Domain/Entities/ProductType.cs
@@ -1,0 +1,31 @@
+﻿#region License
+/*
+ * Copyright 2017 Brandon James
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#endregion
+
+using Newtonsoft.Json;
+
+namespace ShipStation4Net.Domain.Entities
+{
+    public class ProductType : Product
+    {
+        /// <summary>
+        /// The system generated identifier for the product type.
+        /// </summary>
+        [JsonProperty("productTypeId")]
+        public int? ProductTypeId { get; set; }
+    }
+}

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,6 @@
+#### 1.0.4 - 14.12.2022
+* Added ProductType entity and changed property on Product entity
+
 #### 1.0.3 - 05.10.2022
 * Fixed issue with Void Shipment Label api endpoint
 


### PR DESCRIPTION
ShipStation confirmed that the API documentation is wrong.  The ProductType property on the Product model is an object and is a variant of the Product.  The knowledgebase has relevant information, but there is not a page with the Model definition.  https://help.shipstation.com/hc/en-us/articles/360026158491-Product-Types  Attached is the response for a product with a product type.

[productReturn.json.pdf](https://github.com/marketvision/ShipStation4Net/files/10232261/productReturn.json.pdf)
